### PR TITLE
Release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Release 1.2.1
+
+* 1abbb24 [bugfix] remove 6.2 from meta
+
 ## Release 1.2.0
 
 * 0b0b480 [feature] support OpenBSD (#16)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
 #   - 5.9
     - 6.0
     - 6.1
-    - 6.2
+#   - 6.2
   - name: Ubuntu
     versions:
     - trusty


### PR DESCRIPTION
@mitsururike @supachots Release 1.2.1

remove 6.2 from meta

because galaxy bails out when the ansible it uses does not include the
latest release.

https://github.com/ansible/galaxy-issues/issues/296